### PR TITLE
Extend video config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Enter your API key, the prompt, configure the video parameters and click
 **Generate**. When the generation completes you will be asked where to save the
 resulting video file.
 
+The interface also exposes optional settings from `GenerateVideosConfig`:
+
+- **FPS** – frames per second for the output video.
+- **Aspect Ratio** – choose 16:9 or 9:16.
+- **Seed** – fixed seed for reproducible results.
+- **Negative Prompt** – specify concepts to avoid.
+- **Generate Audio** – include audio in the generated clip.
+
 ## Testing
 
 Unit tests require `pytest`. Install it along with the normal dependencies and

--- a/app.py
+++ b/app.py
@@ -41,17 +41,53 @@ class VideoApp(tk.Tk):
             row=3, column=1, sticky="w"
         )
 
+        # FPS spinbox
+        tk.Label(self, text="FPS:").grid(row=4, column=0, sticky="e")
+        self.fps_var = tk.IntVar(value=24)
+        tk.Spinbox(self, from_=1, to=120, textvariable=self.fps_var, width=5).grid(
+            row=4, column=1, sticky="w"
+        )
+
+        # Aspect ratio dropdown
+        tk.Label(self, text="Aspect Ratio:").grid(row=5, column=0, sticky="e")
+        self.aspect_ratio_var = tk.StringVar(value="16:9")
+        ttk.Combobox(
+            self,
+            textvariable=self.aspect_ratio_var,
+            values=["16:9", "9:16"],
+            state="readonly",
+            width=10,
+        ).grid(row=5, column=1, sticky="w")
+
+        # Seed spinbox
+        tk.Label(self, text="Seed:").grid(row=6, column=0, sticky="e")
+        self.seed_var = tk.IntVar(value=0)
+        tk.Spinbox(self, from_=0, to=2**31 - 1, textvariable=self.seed_var, width=10).grid(
+            row=6, column=1, sticky="w"
+        )
+
+        # Negative prompt
+        tk.Label(self, text="Negative Prompt:").grid(row=7, column=0, sticky="ne")
+        self.negative_prompt_text = tk.Text(self, height=2, width=40)
+        self.negative_prompt_text.grid(row=7, column=1, pady=5)
+
+        # Generate audio option
+        self.generate_audio_var = tk.BooleanVar(value=False)
+        tk.Checkbutton(self, text="Generate Audio", variable=self.generate_audio_var).grid(
+            row=8, column=1, sticky="w"
+        )
+
         # Generate button
         self.generate_btn = tk.Button(self, text="Generate", command=self.generate)
-        self.generate_btn.grid(row=4, column=0, columnspan=2, pady=10)
+        self.generate_btn.grid(row=9, column=0, columnspan=2, pady=10)
 
         # Progress/result label
         self.status_var = tk.StringVar(value="")
-        tk.Label(self, textvariable=self.status_var).grid(row=5, column=0, columnspan=2)
+        tk.Label(self, textvariable=self.status_var).grid(row=10, column=0, columnspan=2)
 
         # Progress bar used as a spinner while polling
         self.progress = ttk.Progressbar(self, mode="indeterminate", length=200)
-        self.progress.grid(row=6, column=0, columnspan=2, pady=5)
+        self.progress.grid(row=11, column=0, columnspan=2, pady=5)
         self.progress.grid_remove()
         
         # Spinner control variables
@@ -100,12 +136,21 @@ class VideoApp(tk.Tk):
         genai.configure(api_key=api_key)
         model = genai.GenerativeModel("models/veo-2.0-generate-001")
         try:
+            config = {
+                "resolution": self.resolution_var.get(),
+                "duration": int(self.duration_var.get()),
+                "fps": int(self.fps_var.get()),
+                "aspect_ratio": self.aspect_ratio_var.get(),
+                "seed": int(self.seed_var.get()),
+                "generate_audio": bool(self.generate_audio_var.get()),
+            }
+            negative = self.negative_prompt_text.get("1.0", tk.END).strip()
+            if negative:
+                config["negative_prompt"] = negative
+
             operation = model.generate_content(
                 prompt,
-                generation_config={
-                    "resolution": self.resolution_var.get(),
-                    "duration": int(self.duration_var.get()),
-                },
+                generation_config=config,
             )
 
             # Poll until the operation completes and obtain the response

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -41,6 +41,11 @@ class DummyApp:
     def __init__(self):
         self.resolution_var = DummyVar("720p")
         self.duration_var = DummyVar(5)
+        self.fps_var = DummyVar(30)
+        self.aspect_ratio_var = DummyVar("16:9")
+        self.seed_var = DummyVar(42)
+        self.generate_audio_var = DummyVar(True)
+        self.negative_prompt_text = types.SimpleNamespace(get=lambda *args, **kwargs: "avoid cats")
         self.result = None
         self.error = None
 
@@ -68,6 +73,11 @@ def test_generate_worker_success(monkeypatch):
         def generate_content(self, prompt, generation_config):
             assert generation_config["resolution"] == "720p"
             assert generation_config["duration"] == 5
+            assert generation_config["fps"] == 30
+            assert generation_config["aspect_ratio"] == "16:9"
+            assert generation_config["seed"] == 42
+            assert generation_config["generate_audio"] is True
+            assert generation_config["negative_prompt"] == "avoid cats"
             assert prompt == "hello"
             data = base64.b64encode(b"video data").decode()
             part = types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- add optional video generation controls to the GUI
- pass selected options into `GenerateVideosConfig`
- describe optional parameters in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443fbe8818832d830a110b37fb7f20