### PR TITLE
Add API key storage via sqlite and UI dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ pip install -r requirements.txt
 ```
 
 3. Obtain an API key for the Gemini/Veo API and set it when running the app or
-   paste it in the interface.
+   paste it in the interface. Used keys are saved in `~/.veo_api_keys.db` so
+   they can be selected from a dropdown on future runs.
 
 ## Running
 

--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ from typing import Optional
 
 import google.generativeai as genai
 
+import db
+
 
 @dataclass
 class GenerateVideosConfig:
@@ -30,7 +32,13 @@ class VideoApp(tk.Tk):
 
         # API key
         tk.Label(self, text="API Key:").grid(row=0, column=0, sticky="e")
-        self.api_key_entry = tk.Entry(self, width=40, show="*")
+        self.api_key_var = tk.StringVar()
+        self.api_key_entry = ttk.Combobox(
+            self,
+            textvariable=self.api_key_var,
+            values=db.load_keys(),
+            width=40,
+        )
         self.api_key_entry.grid(row=0, column=1, pady=5)
 
         # Prompt
@@ -156,7 +164,9 @@ class VideoApp(tk.Tk):
 
     def generate(self):
         """Generate the video using the provided prompt and configuration."""
-        api_key = self.api_key_entry.get().strip()
+        api_key = self.api_key_var.get().strip()
+        db.save_key(api_key)
+        self.api_key_entry["values"] = db.load_keys()
         prompt = self.prompt_text.get("1.0", tk.END).strip()
         if not api_key or not prompt:
             messagebox.showerror(

--- a/db.py
+++ b/db.py
@@ -1,0 +1,28 @@
+import os
+import sqlite3
+
+_DEFAULT_PATH = os.path.expanduser("~/.veo_api_keys.db")
+
+
+def _connect(path: str = _DEFAULT_PATH) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS api_keys (key TEXT PRIMARY KEY)"
+    )
+    return conn
+
+
+def load_keys(path: str = _DEFAULT_PATH):
+    """Return a list of stored API keys."""
+    with _connect(path) as conn:
+        rows = conn.execute("SELECT key FROM api_keys").fetchall()
+    return [r[0] for r in rows]
+
+
+def save_key(key: str, path: str = _DEFAULT_PATH) -> None:
+    """Insert an API key if it doesn't already exist."""
+    if not key:
+        return
+    with _connect(path) as conn:
+        conn.execute("INSERT OR IGNORE INTO api_keys (key) VALUES (?)", (key,))
+        conn.commit()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,15 @@
+import db
+
+
+def test_load_save_cycle(tmp_path):
+    db_path = tmp_path / "keys.db"
+    assert db.load_keys(path=str(db_path)) == []
+
+    db.save_key("abc", path=str(db_path))
+    assert db.load_keys(path=str(db_path)) == ["abc"]
+
+    db.save_key("abc", path=str(db_path))
+    assert db.load_keys(path=str(db_path)) == ["abc"]
+
+    db.save_key("def", path=str(db_path))
+    assert set(db.load_keys(path=str(db_path))) == {"abc", "def"}


### PR DESCRIPTION
## Summary
- implement `db.py` using sqlite3 to track API keys
- load keys into dropdown on startup and save new keys when used
- document database location in README
- cover db module with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684460b888ec832db39a5dd670aada19