### PR TITLE
Fix long line conditions and wrap test data

### DIFF
--- a/app.py
+++ b/app.py
@@ -276,15 +276,19 @@ class VideoApp(tk.Tk):
                 part = response.candidates[0].content.parts[0]
                 if hasattr(part, "inline_data") and part.inline_data.data:
                     video_bytes = base64.b64decode(part.inline_data.data)
-                elif hasattr(part, "file_data") and part.file_data.file_uri:
-                    # If a file URI is provided, attempt to download the
-                    # content
-                    import urllib.request
+                else:
+                    has_file_data = (
+                        getattr(part, "file_data", None) is not None
+                    )
+                    if has_file_data and part.file_data.file_uri:
+                        # If a file URI is provided, attempt to download the
+                        # content
+                        import urllib.request
 
-                    with urllib.request.urlopen(
-                        part.file_data.file_uri
-                    ) as resp:
-                        video_bytes = resp.read()
+                        with urllib.request.urlopen(
+                            part.file_data.file_uri
+                        ) as resp:
+                            video_bytes = resp.read()
             except Exception:
                 pass
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -89,7 +89,9 @@ def test_generate_worker_success(monkeypatch):
                 )
                 content = types.SimpleNamespace(parts=[part])
                 candidate = types.SimpleNamespace(content=content)
-                result = types.SimpleNamespace(candidates=[candidate])
+                result = types.SimpleNamespace(
+                    candidates=[candidate]
+                )
                 return FakeOperation(result_obj=result)
 
             self.models = types.SimpleNamespace(
@@ -170,7 +172,9 @@ def test_generate_worker_operation_error(monkeypatch):
     class FakeClient:
         def __init__(self):
             def generate_videos(prompt, *, model, generation_config):
-                result = types.SimpleNamespace(candidates=[])
+                result = types.SimpleNamespace(
+                    candidates=[]
+                )
                 return FakeOperation(
                     result_obj=result,
                     error=types.SimpleNamespace(message="bad prompt"),
@@ -196,7 +200,9 @@ def test_generate_worker_operation_error_delayed(monkeypatch):
     class FakeClient:
         def __init__(self):
             def generate_videos(prompt, *, model, generation_config):
-                result = types.SimpleNamespace(candidates=[])
+                result = types.SimpleNamespace(
+                    candidates=[]
+                )
                 return FakeOperation(
                     result_obj=result,
                     error=types.SimpleNamespace(message="delayed bad"),


### PR DESCRIPTION
## Summary
- assign `has_file_data` to keep long conditions short
- wrap `SimpleNamespace` test objects onto two lines

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844a259b740832dbfa4bdb3bf36c16d