### PR TITLE
Update generative client usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ pip install -r requirements.txt
 
 ## How It Works
 
-The application configures a `google.generativeai.GenerativeClient` with your
-API key and calls `client.models.generate_videos()` to produce the output clip.
+The application configures the library with your API key and obtains a client
+using `genai.client.get_default_generative_client()`. It then calls
+`client.models.generate_videos()` to produce the output clip.
 The helper methods in `db.py` manage the stored keys, and the GUI polls the
 long‑running operation until a result is ready.
 

--- a/app.py
+++ b/app.py
@@ -148,7 +148,7 @@ class VideoApp(tk.Tk):
     def _generate_worker(self, api_key: str, prompt: str) -> None:
         """Background thread that performs the API call."""
         genai.configure(api_key=api_key)
-        client = genai.GenerativeClient()
+        client = genai.client.get_default_generative_client()
 
         spinner_stop = threading.Event()
         spinner_thread = None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,9 @@ import types
 # Provide a minimal stub for google.generativeai so that app.py can be imported
 genai_stub = types.ModuleType("google.generativeai")
 genai_stub.configure = lambda api_key: None
-genai_stub.GenerativeClient = object
+genai_stub.client = types.SimpleNamespace(
+    get_default_generative_client=lambda: object
+)
 google_pkg = types.ModuleType("google")
 google_pkg.__path__ = []
 sys.modules.setdefault("google", google_pkg)
@@ -85,7 +87,11 @@ def test_generate_worker_success(monkeypatch):
             )
 
     monkeypatch.setattr(app.genai, "configure", fake_configure)
-    monkeypatch.setattr(app.genai, "GenerativeClient", lambda: FakeClient())
+    monkeypatch.setattr(
+        app.genai.client,
+        "get_default_generative_client",
+        lambda: FakeClient(),
+    )
 
     app.VideoApp._generate_worker(dummy, "APIKEY", "hello")
 
@@ -110,7 +116,11 @@ def test_generate_worker_error(monkeypatch):
             )
 
     monkeypatch.setattr(app.genai, "configure", fake_configure)
-    monkeypatch.setattr(app.genai, "GenerativeClient", lambda: FakeClient())
+    monkeypatch.setattr(
+        app.genai.client,
+        "get_default_generative_client",
+        lambda: FakeClient(),
+    )
 
     app.VideoApp._generate_worker(dummy, "KEY", "prompt")
 
@@ -140,7 +150,11 @@ def test_generate_worker_error_delayed(monkeypatch):
             )
 
     monkeypatch.setattr(app.genai, "configure", lambda api_key: None)
-    monkeypatch.setattr(app.genai, "GenerativeClient", lambda: FakeClient())
+    monkeypatch.setattr(
+        app.genai.client,
+        "get_default_generative_client",
+        lambda: FakeClient(),
+    )
 
     # Run worker; callback is stored but not executed yet
     app.VideoApp._generate_worker(dummy, "KEY", "prompt")
@@ -171,7 +185,11 @@ def test_generate_worker_operation_error(monkeypatch):
             )
 
     monkeypatch.setattr(app.genai, "configure", lambda api_key: None)
-    monkeypatch.setattr(app.genai, "GenerativeClient", lambda: FakeClient())
+    monkeypatch.setattr(
+        app.genai.client,
+        "get_default_generative_client",
+        lambda: FakeClient(),
+    )
 
     app.VideoApp._generate_worker(dummy, "KEY", "prompt")
 
@@ -199,7 +217,11 @@ def test_generate_worker_operation_error_delayed(monkeypatch):
             )
 
     monkeypatch.setattr(app.genai, "configure", lambda api_key: None)
-    monkeypatch.setattr(app.genai, "GenerativeClient", lambda: FakeClient())
+    monkeypatch.setattr(
+        app.genai.client,
+        "get_default_generative_client",
+        lambda: FakeClient(),
+    )
 
     # Run worker; callback is stored but not executed yet
     app.VideoApp._generate_worker(dummy, "KEY", "prompt")
@@ -327,7 +349,11 @@ def test_generate_worker_fetch_error(monkeypatch):
             )
 
     monkeypatch.setattr(app.genai, "configure", lambda api_key: None)
-    monkeypatch.setattr(app.genai, "GenerativeClient", lambda: FakeClient())
+    monkeypatch.setattr(
+        app.genai.client,
+        "get_default_generative_client",
+        lambda: FakeClient(),
+    )
 
     app.VideoApp._generate_worker(dummy, "KEY", "prompt")
 


### PR DESCRIPTION
## Summary
- use `genai.client.get_default_generative_client()` to create the client
- adjust tests for new client creation method
- document new method in README

## Testing
- `pip install -r requirements.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a934b074832d8cca1489138df180