### PR TITLE
Update generative client import

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import time
 from dataclasses import asdict, dataclass
 
 import google.generativeai as genai
+from google.generativeai import client as genai_client
 
 import db
 
@@ -148,7 +149,7 @@ class VideoApp(tk.Tk):
     def _generate_worker(self, api_key: str, prompt: str) -> None:
         """Background thread that performs the API call."""
         genai.configure(api_key=api_key)
-        client = genai.client.get_default_generative_client()
+        client = genai_client.get_default_generative_client()
 
         spinner_stop = threading.Event()
         spinner_thread = None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,13 +6,14 @@ import types
 # Provide a minimal stub for google.generativeai so that app.py can be imported
 genai_stub = types.ModuleType("google.generativeai")
 genai_stub.configure = lambda api_key: None
-genai_stub.client = types.SimpleNamespace(
-    get_default_generative_client=lambda: object
-)
+client_stub = types.ModuleType("google.generativeai.client")
+client_stub.get_default_generative_client = lambda: object
+genai_stub.client = client_stub
 google_pkg = types.ModuleType("google")
 google_pkg.__path__ = []
 sys.modules.setdefault("google", google_pkg)
 sys.modules["google.generativeai"] = genai_stub
+sys.modules["google.generativeai.client"] = client_stub
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -88,7 +89,7 @@ def test_generate_worker_success(monkeypatch):
 
     monkeypatch.setattr(app.genai, "configure", fake_configure)
     monkeypatch.setattr(
-        app.genai.client,
+        app.genai_client,
         "get_default_generative_client",
         lambda: FakeClient(),
     )
@@ -117,7 +118,7 @@ def test_generate_worker_error(monkeypatch):
 
     monkeypatch.setattr(app.genai, "configure", fake_configure)
     monkeypatch.setattr(
-        app.genai.client,
+        app.genai_client,
         "get_default_generative_client",
         lambda: FakeClient(),
     )
@@ -151,7 +152,7 @@ def test_generate_worker_error_delayed(monkeypatch):
 
     monkeypatch.setattr(app.genai, "configure", lambda api_key: None)
     monkeypatch.setattr(
-        app.genai.client,
+        app.genai_client,
         "get_default_generative_client",
         lambda: FakeClient(),
     )
@@ -186,7 +187,7 @@ def test_generate_worker_operation_error(monkeypatch):
 
     monkeypatch.setattr(app.genai, "configure", lambda api_key: None)
     monkeypatch.setattr(
-        app.genai.client,
+        app.genai_client,
         "get_default_generative_client",
         lambda: FakeClient(),
     )
@@ -218,7 +219,7 @@ def test_generate_worker_operation_error_delayed(monkeypatch):
 
     monkeypatch.setattr(app.genai, "configure", lambda api_key: None)
     monkeypatch.setattr(
-        app.genai.client,
+        app.genai_client,
         "get_default_generative_client",
         lambda: FakeClient(),
     )
@@ -350,7 +351,7 @@ def test_generate_worker_fetch_error(monkeypatch):
 
     monkeypatch.setattr(app.genai, "configure", lambda api_key: None)
     monkeypatch.setattr(
-        app.genai.client,
+        app.genai_client,
         "get_default_generative_client",
         lambda: FakeClient(),
     )


### PR DESCRIPTION
## Summary
- add genai_client import from `google.generativeai`
- call `genai_client.get_default_generative_client`
- update tests for new import location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ad1d6184832d9ee4367ede7310f6