### PR TITLE
Switch to GenerativeModel video generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ pip install -r requirements.txt
 ## How It Works
 
 The application configures the library with your API key using
-`genai.configure(api_key)` and obtains a client via
-`google.generativeai.client.get_default_generative_client()`. It then calls the
-client's `models.generate_videos()` method to produce the output clip.
+`genai.configure(api_key)` and instantiates a
+`genai.GenerativeModel` object. It then calls the model's
+`generate_content()` method to produce the output clip.
 The helper methods in `db.py` manage the stored keys, and the GUI polls the
 long‑running operation until a result is ready.
 


### PR DESCRIPTION
## Summary
- use `genai.GenerativeModel` instead of deprecated client API for video generation
- update unit tests for new API
- clarify README description

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453e919584832dbbe70c4468f55e63